### PR TITLE
Remove uses of --harmony flag

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,7 +1,7 @@
 module.exports = {
   parser: '@typescript-eslint/parser',
   parserOptions: {
-    ecmaVersion: 2019,
+    ecmaVersion: 2020,
     sourceType: 'module',
   },
   plugins: [

--- a/README.md
+++ b/README.md
@@ -67,11 +67,6 @@ When transpiling, [TypeScript won't generate an extension for you](https://githu
 Otherwise, [node mandates that you specify the extension](https://nodejs.org/api/esm.html#esm_mandatory_file_extensions) in the `import` statement.
 
 
-# Optional chaining
-
-To support optional chaining, add the `--harmony` flag to the node command line.
-
-
 # Run the resulting JavaScript code
 
 Add `"type": "module"` to `package.json`, because [TypeScript can't generate files with the .mjs extension](https://github.com/microsoft/TypeScript/issues/18442#issuecomment-581738714).

--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
     "build": "npm run clean && tsc",
     "clean": "rm -f *.js *.js.map",
     "lint": "eslint *.ts",
-    "start": "node --experimental-specifier-resolution=node --harmony -r source-map-support/register run.js",
-    "test": "node --harmony node_modules/.bin/jest"
+    "start": "node --experimental-specifier-resolution=node -r source-map-support/register run.js",
+    "test": "node node_modules/.bin/jest"
   },
   "dependencies": {
     "influx": "^5.6.0"
@@ -37,6 +37,6 @@
     "typescript": "^3.9.7"
   },
   "engines": {
-    "node": ">=13.0.0"
+    "node": ">=14.0.0"
   }
 }


### PR DESCRIPTION
Node.js v13 has been EOL for a long time now and [v12 will reach EOL by the end of April](https://nodejs.org/en/about/releases/).

As of Node.js v14 and above, [optional chaining no longer requires `--harmony` flag and has nearly full support of ES2020](https://node.green/#ES2020-features-optional-chaining-operator-----), therefore it's no longer needed and ESLint can also be bumped to ecmaVersion 2020.